### PR TITLE
feat: Socket 전송 시 userId 포함 및 멀티 유저 대응 구현

### DIFF
--- a/routes/transcribe.py
+++ b/routes/transcribe.py
@@ -12,8 +12,9 @@ def transcribe():
       return jsonify({"error": "스트리밍 URL이 제공되지 않았습니다."}), 400
 
     url = data.get("url")
+    userId = data.get("userId")
     print(f"받은 스트리밍 URL: {url}")
-    transcribe_radio_stream(url)
+    transcribe_radio_stream(url, userId)
 
   except Exception as e:
     print(f"오류 발생: {e}")

--- a/services/whisper_service.py
+++ b/services/whisper_service.py
@@ -10,9 +10,9 @@ text_queue = queue.Queue()
 
 socketio = socketio.Client()
 # TODO: Whisper 서버 배포 시 주소 변경
-socketio.connect("http://localhost:3000")
+socketio.connect("http://localhost:3000/whisper")
 
-def transcribe_radio_stream(url):
+def transcribe_radio_stream(url, userId):
   def worker():
     try:
       process = subprocess.Popen(
@@ -39,7 +39,7 @@ def transcribe_radio_stream(url):
         text = result.get("text", "").strip()
 
         if text:
-          socketio.emit("transcribedRadioText", {"text": text})
+          socketio.emit("transcribedRadioText", { "text": text, "userId": userId })
           print(f"[전송됨] {text}")
 
     except Exception as e:


### PR DESCRIPTION
### ✨ 이슈 번호

- #9

### 📌 설명

- `transcribe_radio_stream()` 실행 시 `userId`를 socket.emit에 포함되도록 구현하여 작성한 Pull Request입니다.
- 여러 유저가 Whisper 서버에 동시에 접근할 경우에도 각각의 `userId` 유지하도록 구현합니다.

### 📃 작업 사항

- [x] `socketio.emit("transcribedRadioText", { text, userId })`에 userId 포함
- [x] `transcribe_radio_stream()` 내부 `userId` logging 추가

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
