### PR TITLE
feat: whisper 네임스페이스 소켓 통신 적용

### DIFF
--- a/routes/transcribe.py
+++ b/routes/transcribe.py
@@ -16,6 +16,8 @@ def transcribe():
     print(f"받은 스트리밍 URL: {url}")
     transcribe_radio_stream(url, userId)
 
+    return jsonify({"message": "transcribe start"}), 200
+
   except Exception as e:
     print(f"오류 발생: {e}")
     return jsonify({"error": "서버 오류가 발생했습니다."}), 500

--- a/services/whisper_service.py
+++ b/services/whisper_service.py
@@ -9,8 +9,17 @@ model = whisper.load_model("base", device="cpu")
 text_queue = queue.Queue()
 
 socketio = socketio.Client()
+
+@socketio.event(namespace="/whisper")
+def connect():
+    print("Whisper namespace connected")
+
+@socketio.event(namespace="/whisper")
+def disconnect():
+    print("Whisper namespace disconnected")
+
 # TODO: Whisper 서버 배포 시 주소 변경
-socketio.connect("http://localhost:3000/whisper")
+socketio.connect("http://localhost:3000", namespaces=["/whisper"])
 
 def transcribe_radio_stream(url, userId):
   def worker():
@@ -39,7 +48,7 @@ def transcribe_radio_stream(url, userId):
         text = result.get("text", "").strip()
 
         if text:
-          socketio.emit("transcribedRadioText", { "text": text, "userId": userId })
+          socketio.emit("transcribedRadioText", { "text": text, "userId": userId }, namespace="/whisper")
           print(f"[전송됨] {text}")
 
     except Exception as e:


### PR DESCRIPTION
### ✨ 이슈 번호

- #11 

### 📌 설명

- 클라이언트-서버 간 소켓 연결을 /whisper 네임스페이스를 통해 명확히 분리하도록 구현하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] Whisper 소켓 연결을 `/whisper` 네임스페이스로 분리
- [x] Whisper 소켓 연결 시 connect/disconnect 로그 추가
- [x] transcribe 함수 응답에 status 200 반환 추가

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
