### PR TITLE
fix: 사용자 채널 이동 후 광고 감지 및 복귀 로직 에러 해결을 위한 channelId 추가

### DIFF
--- a/routes/transcribe.py
+++ b/routes/transcribe.py
@@ -13,8 +13,9 @@ def transcribe():
 
     url = data.get("url")
     userId = data.get("userId")
+    channelId = data.get("channelId")
     print(f"받은 스트리밍 URL: {url}")
-    transcribe_radio_stream(url, userId)
+    transcribe_radio_stream(url, userId, channelId)
 
     return jsonify({"message": "transcribe start"}), 200
 

--- a/services/whisper_service.py
+++ b/services/whisper_service.py
@@ -36,7 +36,7 @@ def disconnect():
 # TODO: Whisper 서버 배포 시 주소 변경
 socketio.connect("http://localhost:3000", namespaces=["/whisper"])
 
-def transcribe_radio_stream(url, userId):
+def transcribe_radio_stream(url, userId, channelId):
   def worker():
     try:
       process = subprocess.Popen(
@@ -66,7 +66,7 @@ def transcribe_radio_stream(url, userId):
         if text:
           clear_spaces_text = re.sub(r"\s+", "", text)
           save_transcription_log(clear_spaces_text, userId)
-          socketio.emit("transcribedRadioText", { "text": text, "userId": userId }, namespace="/whisper")
+          socketio.emit("transcribedRadioText", { "text": clear_spaces_text, "userId": userId, "channelId": channelId }, namespace="/whisper")
           print(f"[전송됨] {text}")
 
     except Exception as e:


### PR DESCRIPTION
### ✨ 이슈 번호

- #17

### 📌 설명

- Whisper 서버가 transcribe 결과를 전송할 때 channelId를 함께 전달하도록 변경을 구현하여 작성한 Pull Request입니다.
- 백엔드 사용자 채널 이동 후 광고 감지 및 복귀 로직 에러 해결을 위한 channelId 추가입니다.

### 📃 작업 사항

- [x] Whisper 서버의 transcribe_radio_stream 함수에 channelId 인자 추가
- [x] /transcribe API 요청 시 channelId도 함께 전달
- [x] transcribedRadioText 이벤트 emit 시 channelId 포함

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
