### PR TITLE
refactor: 환경 변수 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 venv
+
+.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ python-socketio==5.11.1
 requests==2.31.0
 torch==2.7.0
 Werkzeug==3.1.3
+python-dotenv==1.1.0

--- a/services/whisper_service.py
+++ b/services/whisper_service.py
@@ -1,15 +1,21 @@
-import socketio
-import subprocess
-import whisper
-import numpy
-import threading
-import queue
-import csv
-from datetime import datetime
 import os
-from .logger import save_transcription_log
+import csv
 import re
+import queue
+import threading
+import subprocess
+from datetime import datetime
+
+import socketio
+import numpy
+import whisper
+from dotenv import load_dotenv
+
+from .logger import save_transcription_log
 from services.process_registry import active_processes
+
+load_dotenv()
+BACKEND_API_URL = os.getenv("BACKEND_API_URL")
 
 LOG_FILE_PATH = "data/whisper_logs.csv"
 os.makedirs(os.path.dirname(LOG_FILE_PATH), exist_ok=True)
@@ -22,7 +28,6 @@ def save_transcription_log(text, userId):
 
 model = whisper.load_model("base", device="cpu")
 text_queue = queue.Queue()
-
 socketio = socketio.Client()
 
 @socketio.event(namespace="/whisper")
@@ -33,8 +38,7 @@ def connect():
 def disconnect():
     print("Whisper namespace disconnected")
 
-# TODO: Whisper 서버 배포 시 주소 변경
-socketio.connect("http://localhost:3000", namespaces=["/whisper"])
+socketio.connect(BACKEND_API_URL, namespaces=["/whisper"])
 
 def transcribe_radio_stream(url, userId, channelId):
   def worker():


### PR DESCRIPTION
### ✨ 이슈 번호

- #19 

### 📌 설명

- 백엔드 서버 요청에 필요한 환경 변수로 분리를 구현하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] `.env` 추가
  - [x] `.env`에 `BACKEND_API_URL` 추가
- [x] env 참조 수정
  - [x] 백엔드 관련 요청 코드에서 `BACKEND_API_URL` 참조하도록 수정
- [x] `.gitignore`에 `.env` 추가
- [x] `python-dotenv` 설치 후 `requirements.txt`에 추가
  - [x] `pip3 install python-dotenv`
  - [x] `python-dotenv==1.1.0` 추가
- [x] import 정렬 : 표준 라이브러리 -> 서드파티 -> 로컬 모듈

### 💡 참고 사항

- Express 백엔드는 3000번에서 운영됩니다.
- 향후 도메인 기반으로 운영될 예정입니다.

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
